### PR TITLE
This PR fixes event emission for psp34_standard contract

### DIFF
--- a/Azero_Contracts/contracts/psp34_standard/Cargo.toml
+++ b/Azero_Contracts/contracts/psp34_standard/Cargo.toml
@@ -13,6 +13,9 @@ scale-info = { version = "2.3", default-features = false, features = ["derive"],
 openbrush = { tag = "3.0.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = ["psp34", "ownable", "access_control"] }
 artzero_project = { path = "../..", default-features = false }
 
+[dev-dependencies]
+ink_e2e = { version = "4.0" }
+
 [lib]
 name = "psp34_nft"
 path = "lib.rs"
@@ -31,9 +34,12 @@ std = [
     "artzero_project/std"
 ]
 ink-as-dependency = []
+e2e-tests = []
+
 
 [profile.dev]
 codegen-units = 16
 
 [profile.release]
 overflow-checks = false
+


### PR DESCRIPTION
Openbrush does not implement their internal `_emit_event` functions for transfer and approval. Without this internal implementation, the ArtZero psp34 standard contract cannot emit events. This PR contains an implementation for Approval and Transfer, plus an e2e test that may be used to verify this assertion.